### PR TITLE
envsetup.sh: Fix The Path For Aimlog.sh

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1720,5 +1720,5 @@ check_bash_version && {
 
 export ANDROID_BUILD_TOP=$(gettop)
 
-. $ANDROID_BUILD_TOP/vendor/aim/build/envsetup.sh&& ./vendor/aim/extra/aimlog.sh
+. $ANDROID_BUILD_TOP/vendor/aim/build/envsetup.sh&& . vendor/aim/extra/aimlog.sh
 


### PR DESCRIPTION
*-bash: ./vendor/aim/extra/aimlog.sh: Permission denied
When you run . build/envsetup.sh
The correct way is this.